### PR TITLE
performance.now polyfill

### DIFF
--- a/lib/deferred/animate.js
+++ b/lib/deferred/animate.js
@@ -51,6 +51,32 @@ if( !_requestAnimationFrame ) (function () {
   }
 })();
 
+// FROM: https://gist.github.com/paulirish/5438650
+(function(){
+
+  if ('performance' in window == false) {
+      window.performance = {};
+  }
+
+  Date.now = (Date.now || function () {  // thanks IE8
+    return new Date().getTime();
+  });
+
+  if ('now' in window.performance == false){
+
+    var nowOffset = Date.now();
+
+    if (performance.timing && performance.timing.navigationStart){
+      nowOffset = performance.timing.navigationStart;
+    }
+
+    window.performance.now = function now(){
+      return Date.now() - nowOffset;
+    };
+  }
+
+})();
+
 function animate (progressFn, duration, atEnd, timingFunctionName) {
   var aux;
   if ( duration instanceof Function ) {


### PR DESCRIPTION
`Mac > Mavericks > Safari 7.1` no soporta el método de `perfomance.now()` y da un error que rompe el checkout. He encontrado un polyfill del Paul Irish y ademas de no romper el checkout hace las animaciones bien.
Por curiosidad, el error en concreto da en este línea: https://github.com/aplazame/vanilla-tools/blob/master/lib/deferred/animate.js#L78
Si que debe soporta `requestAnimationFrame` pero no el performance.